### PR TITLE
Corrige procedures de relatório GR_J1

### DIFF
--- a/api/models/sql_declarative.py
+++ b/api/models/sql_declarative.py
@@ -322,13 +322,13 @@ class AggrJournalLanguageYearMonthMetric(Base):
 
 class AggrJournalGeolocationYearMonthMetric(Base):
     __tablename__ = 'aggr_journal_geolocation_year_month_metric'
-    __table_args__ = (UniqueConstraint('year_month', 'journal_id', 'country_code', name='uni_jou_geo_ajlymm'),)
+    __table_args__ = (UniqueConstraint('year_month', 'journal_id', 'country_code', name='uni_jou_geo_ajgymm'),)
     __table_args__ += (Index('idx_ym_id', 'year_month', 'journal_id'),)
 
     id = Column(INTEGER(unsigned=True), primary_key=True, autoincrement=True)
 
     collection = Column(VARCHAR(3), nullable=False, primary_key=True)
-    journal_id = Column(INTEGER(unsigned=True), ForeignKey('counter_journal.id', name='idjournal_ajlymm'))
+    journal_id = Column(INTEGER(unsigned=True), ForeignKey('counter_journal.id', name='idjournal_ajgymm'))
     country_code = Column(VARCHAR(4), nullable=False)
     year_month = Column(VARCHAR(7), nullable=False)
 

--- a/api/static/sql/procedures_v2_gr_j1.sql
+++ b/api/static/sql/procedures_v2_gr_j1.sql
@@ -24,12 +24,12 @@ BEGIN
 		`year_month` BETWEEN beginDate AND endDate
 	GROUP BY
 		journalID,
-		countryCode,
-		yearMonth
+		yearMonth,
+		countryCode
 	ORDER BY
 		journalID,
-		countryCode,
-		yearMonth
+		yearMonth,
+		countryCode
 	;
 END $$
 DELIMITER ;
@@ -97,12 +97,12 @@ BEGIN
 	    (online_issn <> '' OR print_issn <> '')
 	GROUP BY
 	 	journalID,
-	 	countryCode,
-	 	yearMonth
+	 	yearMonth,
+		countryCode
 	ORDER BY
 		journalID,
-		countryCode,
-		yearMonth
+		yearMonth,
+		countryCode
 	;
 END $$
 DELIMITER ;


### PR DESCRIPTION
#### O que esse PR faz?
Altera a ordem em que as linhas são apresentadas pelas procedures de relatórios GR_J1. A nova ordem passa a ser:
1. JournalID
2. YearMonth
3. CountryCode

Os relatórios em formato TSV estavam apresentado as colunas dos meses/ano de forma desordenada. Este PR corrige essa situação.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

#### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

#### Referências
N/A