### PR TITLE
Corrige procedures gerados de relatórios ir_a1

### DIFF
--- a/api/models/sql_declarative.py
+++ b/api/models/sql_declarative.py
@@ -207,6 +207,7 @@ class SushiArticleMetric(Base):
     unique_item_requests = Column(INTEGER, nullable=False)
     unique_item_investigations = Column(INTEGER, nullable=False)
 
+
 class Institution(Base):
     __tablename__ = 'counter_institution'
 

--- a/api/static/sql/procedures.sql
+++ b/api/static/sql/procedures.sql
@@ -227,6 +227,7 @@ BEGIN
              JOIN counter_journal cj on ca.idjournal_a = cj.id
              JOIN counter_journal_collection cjc on cj.id = cjc.idjournal_jc
     WHERE (ca.collection = collection_acronym) AND
+          (cjc.collection = collection_acronym) AND
           (issn = online_issn OR issn = print_issn OR issn = pid_issn) AND
           (year_month_day between beginDate AND endDate) AND
           (online_issn <> '' OR print_issn <> '')
@@ -257,6 +258,7 @@ BEGIN
              JOIN counter_journal cj on ca.idjournal_a = cj.id
              JOIN counter_journal_collection cjc on cj.id = cjc.idjournal_jc
     WHERE (ca.collection = collection_acronym) AND
+          (cjc.collection = collection_acronym) AND
           (issn = online_issn OR issn = print_issn OR issn = pid_issn) AND
           (year_month_day between beginDate AND endDate) AND
           (online_issn <> '' OR print_issn <> '')
@@ -285,6 +287,7 @@ BEGIN
              JOIN counter_journal cj on ca.idjournal_a = cj.id
              JOIN counter_journal_collection cjc on cj.id = cjc.idjournal_jc
     WHERE (ca.collection = collection_acronym) AND
+          (cjc.collection = collection_acronym) AND
           (pid = ca.pid) AND
           (year_month_day between beginDate AND endDate) AND
           (online_issn <> '' OR print_issn <> '');
@@ -313,6 +316,7 @@ BEGIN
              JOIN counter_journal cj on ca.idjournal_a = cj.id
              JOIN counter_journal_collection cjc on cj.id = cjc.idjournal_jc
     WHERE (ca.collection = collection_acronym) AND
+          (cjc.collection = collection_acronym) AND
           (pid = ca.pid) AND
           (year_month_day between beginDate AND endDate) AND
           (online_issn <> '' OR print_issn <> '')
@@ -342,6 +346,7 @@ BEGIN
              JOIN counter_journal cj on ca.idjournal_a = cj.id
              JOIN counter_journal_collection cjc on cj.id = cjc.idjournal_jc
     WHERE (ca.collection = collection_acronym) AND
+          (cjc.collection = collection_acronym) AND
           (year_month_day between beginDate AND endDate) AND
           (online_issn <> '' OR print_issn <> '')
     GROUP BY ca.pid, yearMonth;
@@ -369,6 +374,7 @@ BEGIN
              JOIN counter_journal cj on ca.idjournal_a = cj.id
              JOIN counter_journal_collection cjc on cj.id = cjc.idjournal_jc
     WHERE (ca.collection = collection_acronym) AND
+          (cjc.collection = collection_acronym) AND
           (year_month_day between beginDate AND endDate) AND
           (online_issn <> '' OR print_issn <> '')
     GROUP BY ca.pid;


### PR DESCRIPTION
Este PR corrige as seis procedures responsáveis por gerar relatórios IR_A1.

A correção trata de evitar que os valores das métricas sejam apresentados de forma duplicada. Segue uma descrição mais detalhada:

Foi identificada uma situação de erro nos relatórios de acesso por artigo. O erro consiste em apresentar os dados de acesso de forma duplicada, isto é, com valor de contagem de acessos multiplicado por dois. Ressalta-se que esse erro não impactou outros relatórios tais como aqueles nos níveis de periódico e coleção, por exemplo. Trata-se de um erro da função ou procedure que agrega os dados por artigo e coleção. Como um artigo pode estar em mais de uma coleção, a procedure reponsável por fazer essa agregação estava com um erro de codificação. Fez-se a correção das seis procedures relacionados aos relatórios ir_a1.