### PR TITLE
Cria relatório LR_A1

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -11,6 +11,9 @@ def generate_output(request, fmt, report_id, data, params, exceptions):
 
 
 def json_report_wrapper(report_id, result_query, params, exceptions):
+    if report_id == 'lr_a1':
+        return _json_lr_a1(result_query, params, exceptions)
+
     if report_id == 'ir_a1':
         return _json_ir_a1(result_query, params, exceptions)
 
@@ -753,6 +756,9 @@ def _json_gr_j4(result_query_reports_gr_j4, params, exceptions):
 def tsv_report_wrapper(request, report_id, result_query, params, exceptions):
     filename = '_'.join(['report', report_id]) + '.tsv'
     request.response.content_disposition = 'attachment;filename=' + filename
+
+    if report_id == 'lr_a1':
+        return _tsv_report_lr_a1(result_query, params, exceptions)
 
     if report_id == 'ir_a1':
         return _tsv_report_ir_a1(result_query, params, exceptions)

--- a/api/adapter.py
+++ b/api/adapter.py
@@ -951,6 +951,82 @@ def _tsv_report_cr_j1(result_query, params, exceptions):
     return output
 
 
+def _tsv_report_lr_a1(result_query, params, exceptions):
+    begin_date, bd_discard  = cleaner.get_start_and_last_days(params['begin_date'])
+    ed_discard, end_date  = cleaner.get_start_and_last_days(params['end_date'])
+
+    params['begin_date'] = begin_date
+    params['end_date'] = end_date
+
+    result = {'headers': _tsv_header(params, exceptions)}
+
+    article2values = {}
+    yms = ['Reporting_Period_Total']
+
+    for ri in result_query:
+        article_key = (ri.printISSN, ri.onlineISSN, ri.journalTitle, ri.journalURI, ri.journalPublisher, ri.articleCollection, ri.articlePID, ri.articleLanguage)
+
+        tir = getattr(ri, 'totalItemRequests')
+        uir = getattr(ri, 'uniqueItemRequests')
+
+        if article_key not in article2values:
+            article2values[article_key] = {'Reporting_Period_Total': (0, 0)}
+
+        if params['granularity'] == 'monthly':
+            year_month = cleaner.handle_str_date(ri.yearMonth, str_format=False).strftime('%b-%Y')
+            if year_month not in yms:
+                yms.append(year_month)
+
+            if year_month not in article2values[article_key]:
+                article2values[article_key][year_month] = 0
+
+            article2values[article_key][year_month] = (tir, uir)
+
+        article2values[article_key]['Reporting_Period_Total'] = tuple(map(sum, zip(article2values[article_key]['Reporting_Period_Total'], (tir, uir))))
+
+    output = {'rows': []}
+    for k in values.TSV_REPORT_DEFAULT_HEADERS:
+        output['rows'].append([k, result['headers'][k]])
+
+    output['rows'].append(values.TSV_REPORT_LR_A1_ROWS + yms)
+
+    for i in article2values:
+        for j, metric_name in enumerate(['Total_Item_Requests', 'Unique_Item_Requests']):
+            line = [
+                i[6],
+                i[4],
+                '',
+                'SciELO SUSHI API',
+                '',
+                '',
+                i[7],
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                i[2],
+                '',
+                '',
+                '',
+                '',
+                i[0],
+                i[1],
+                i[3],
+                '',
+                metric_name
+            ]
+
+            for ym in yms:
+                ym_v = str(article2values[i].get(ym, (0, 0))[j])
+                line.append(ym_v)
+
+            output['rows'].append(line)
+
+    return output
+
+
 def _tsv_report_ir_a1(result_query, params, exceptions):
     result = {'headers': _tsv_header(params, exceptions, data_type='Article')}
 

--- a/api/libs/db.py
+++ b/api/libs/db.py
@@ -40,7 +40,7 @@ def get_dates_not_ready(begin_date, end_date, collection, report_id):
         else:
             return []
 
-    elif report_id in ('gr_j1', 'lr_j1', 'gr_j4', 'lr_j4'):
+    elif report_id in ('gr_j1', 'lr_j1', 'gr_j4', 'lr_j4', 'lr_a1'):
         if status_column:
             not_read_dates = DBSession.query(AggrStatus).filter(and_(AggrStatus.collection == collection,
                                                                      getattr(AggrStatus, status_column) == 0,

--- a/api/static/json/counter_report.json
+++ b/api/static/json/counter_report.json
@@ -77,6 +77,13 @@
       "Report_Description": "Breaks down the usage of journal content, excluding Gold Open Access content, by year of publication (YOP), providing counts for the Metric_Types Total_Item_Requests and Unique_Item_Requests. Provides the details necessary to analyze usage of content in backfiles or covered by perpetual access agreement. Note that COUNTER reports do not provide access model or perpetual access rights details.",
       "Path": "/reports/tr_j4"
     },
+    "lr_a1": {
+      "Report_Name": "Journal Article Requests by Article_Language (Excluding OA_Gold)",
+      "Report_ID": "lr_a1",
+      "Release": "5",
+      "Report_Description": "Reports on usage of journal article content for all Metric_Types broken down by Article_Language.",
+      "Path": "/reports/lr_a1"
+    },
     "lr_j1": {
       "Report_Name": "Journal Requests by Article Language (Excluding OA_Gold)",
       "Report_ID": "lr_j1",

--- a/api/static/sql/procedures_v2_lr_a1.sql
+++ b/api/static/sql/procedures_v2_lr_a1.sql
@@ -1,0 +1,98 @@
+DELIMITER $$
+CREATE PROCEDURE LR_A1_ARTICLE_TOTALS(IN beginDate varchar(7), IN endDate varchar(7), IN pid varchar(23), IN collection varchar(3))
+BEGIN
+    SELECT
+        cj.print_issn as printISSN,
+        cj.online_issn as onlineISSN,
+        cjc.title as journalTitle,
+        cjc.uri as journalURI,
+        cjc.publisher_name as journalPublisher,
+        ca.collection as articleCollection,
+        ca.pid as articlePID,
+        cal.`language` as articleLanguage,
+		MIN(aalymm.`year_month`) AS beginDate,
+		MAX(aalymm.`year_month`) AS endDate,
+        sum(aalymm.total_item_requests) as totalItemRequests,
+        sum(aalymm.unique_item_requests) as uniqueItemRequests
+    FROM
+        aggr_article_language_year_month_metric aalymm
+    JOIN
+        counter_article ca ON ca.id = aalymm.article_id 
+    JOIN
+        counter_journal cj ON cj.id = ca.idjournal_a 
+    JOIN
+        counter_journal_collection cjc ON cjc.idjournal_jc = ca.idjournal_a 
+    JOIN 
+        counter_article_language cal ON cal.id = aalymm.language_id 
+    WHERE
+        aalymm.article_id in (
+            select 
+                id
+            from 
+                counter_article ca 
+            where 
+                ca.pid = pid AND 
+                ca.collection = collection
+        ) AND
+        cjc.collection = collection AND
+        aalymm.collection = collection AND
+        `year_month` BETWEEN beginDate AND endDate
+    GROUP BY
+        articlePID,
+        articleLanguage
+    ORDER BY
+        articlePID,
+        articleLanguage;
+END $$
+DELIMITER ;
+
+DELIMITER $$
+CREATE PROCEDURE LR_A1_ARTICLE_MONTHLY(IN beginDate varchar(7), IN endDate varchar(7), IN pid varchar(23), IN collection varchar(3))
+BEGIN
+    SELECT
+        cj.print_issn as printISSN,
+        cj.online_issn as onlineISSN,
+        cjc.title as journalTitle,
+        cjc.uri as journalURI,
+        cjc.publisher_name as journalPublisher,
+        ca.collection as articleCollection,
+        ca.pid as articlePID,
+        aalymm.article_id as articleID,
+        aalymm.language_id as languageCode,
+        cal.`language` as articleLanguage,
+        aalymm.`year_month` as yearMonth,
+        sum(aalymm.total_item_requests) as totalItemRequests,
+        sum(aalymm.unique_item_requests) as uniqueItemRequests
+    FROM
+        aggr_article_language_year_month_metric aalymm
+    JOIN
+        counter_article ca ON ca.id = aalymm.article_id 
+    JOIN
+        counter_journal cj ON cj.id = ca.idjournal_a 
+    JOIN
+        counter_journal_collection cjc ON cjc.idjournal_jc = ca.idjournal_a 
+    JOIN 
+        counter_article_language cal ON cal.id = aalymm.language_id 
+    WHERE
+        aalymm.article_id in (
+            select 
+                id
+            from 
+                counter_article ca 
+            where 
+                ca.pid = pid AND 
+                ca.collection = collection
+        ) AND
+        cjc.collection = collection AND
+        aalymm.collection = collection AND
+        `year_month` BETWEEN beginDate AND endDate
+    GROUP BY
+        articleID,
+        languageCode,
+        yearMonth
+    ORDER BY
+        articleID,
+        languageCode,
+        yearMonth;
+END $$
+DELIMITER ;

--- a/api/utils.py
+++ b/api/utils.py
@@ -138,7 +138,7 @@ def wrapper_call_report(report_id, params):
     else:
         procedure_name, params_names = values.GRANULARITY_MODE_REPORT_TO_PROCEDURE_AND_PARAMETERS.get(granularity, {}).get(mode, {}).get(report_id, ('', []))
 
-    if report_id in ('gr_j1', 'lr_j1', 'gr_j4', 'lr_j4'):
+    if report_id in ('gr_j1', 'lr_j1', 'gr_j4', 'lr_j4', 'lr_a1',):
         params['begin_date'] = cleaner.handle_str_date(params['begin_date'], year_month_only=True)
         params['end_date'] = cleaner.handle_str_date(params['end_date'], year_month_only=True)
 

--- a/api/values.py
+++ b/api/values.py
@@ -59,6 +59,9 @@ DB_CALL_TR_J4_JOURNAL_MONTHLY = 'CALL TR_J4_JOURNAL_MONTHLY("%s", "%s", "%s", "%
 DB_CALL_IR_A1_ARTICLE_TOTALS = 'CALL IR_A1_ARTICLE_TOTALS("%s", "%s", "%s", "%s")'
 DB_CALL_IR_A1_ARTICLE_MONTHLY = 'CALL IR_A1_ARTICLE_MONTHLY("%s", "%s", "%s", "%s")'
 
+DB_CALL_LR_A1_ARTICLE_TOTALS = 'CALL LR_A1_ARTICLE_TOTALS("%s", "%s", "%s", "%s")'
+DB_CALL_LR_A1_ARTICLE_MONTHLY = 'CALL LR_A1_ARTICLE_MONTHLY("%s", "%s", "%s", "%s")'
+
 DB_CALL_IR_A1_JOURNAL_TOTALS = 'CALL IR_A1_JOURNAL_TOTALS("%s", "%s", "%s", "%s", "%s")'
 DB_CALL_IR_A1_JOURNAL_MONTHLY = 'CALL IR_A1_JOURNAL_MONTHLY("%s", "%s", "%s", "%s", "%s")'
 
@@ -109,6 +112,7 @@ REPORT_ID_TO_COLUMN_STATUS = {
     'tr_j1': 'status_sushi_journal_metric',
     'tr_j4': 'status_sushi_journal_yop_metric',
     'lr_j1': 'status_aggr_journal_language_year_month_metric',
+    'lr_a1': 'status_aggr_article_language_year_month_metric',
     'lr_j4': 'status_aggr_journal_language_yop_year_month_metric',
     'gr_j1': 'status_aggr_journal_geolocation_year_month_metric',
     'gr_j4': 'status_aggr_journal_geolocation_yop_year_month_metric',
@@ -119,7 +123,8 @@ GRANULARITY_MODE_REPORT_TO_PROCEDURE_AND_PARAMETERS = {
         'pid': {
             'tr_j1': ('', []),
             'tr_j4': ('', []),
-            'ir_a1': (DB_CALL_IR_A1_ARTICLE_TOTALS, ['begin_date', 'end_date', 'pid', 'collection'])
+            'ir_a1': (DB_CALL_IR_A1_ARTICLE_TOTALS, ['begin_date', 'end_date', 'pid', 'collection']),
+            'lr_a1': (DB_CALL_LR_A1_ARTICLE_TOTALS, ['begin_date', 'end_date', 'pid', 'collection']),
         },
         'issn': {
             'tr_j1': (DB_CALL_TR_J1_JOURNAL_TOTALS, ['begin_date', 'end_date', 'issn', 'collection']),
@@ -135,7 +140,8 @@ GRANULARITY_MODE_REPORT_TO_PROCEDURE_AND_PARAMETERS = {
         'pid': {
             'tr_j1': ('', []),
             'tr_j4': ('', []),
-            'ir_a1': (DB_CALL_IR_A1_ARTICLE_MONTHLY, ['begin_date', 'end_date', 'pid', 'collection'])
+            'ir_a1': (DB_CALL_IR_A1_ARTICLE_MONTHLY, ['begin_date', 'end_date', 'pid', 'collection']),
+            'lr_a1': (DB_CALL_LR_A1_ARTICLE_MONTHLY, ['begin_date', 'end_date', 'pid', 'collection']),
         },
         'issn': {
             'tr_j1': (DB_CALL_TR_J1_JOURNAL_MONTHLY, ['begin_date', 'end_date', 'issn', 'collection']),

--- a/api/values.py
+++ b/api/values.py
@@ -335,5 +335,31 @@ TSV_REPORT_IR_ROWS = [
     'Metric_Type',
 ]
 
+TSV_REPORT_LR_A1_ROWS = [
+    'Item',
+    'Publisher',
+    'Publisher_ID',
+    'Platform',
+    'Authors',
+    'Publication_Date',
+    'Article_Language',
+    'Article_Version',
+    'DOI',
+    'Proprietary_ID',
+    'Print_ISSN',
+    'Online_ISSN',
+    'URI',
+    'Parent_Title',
+    'Parent_Authors',
+    'Parent_Article_Version',
+    'Parent_DOI',
+    'Parent_Proprietary_ID',
+    'Parent_Print_ISSN',
+    'Parent_Online_ISSN',
+    'Parent_URI',
+    'Access_Type',
+    'Metric_Type',
+]
+
 MIN_YEAR = 1900
 MAX_YEAR = 2100

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -23,6 +23,7 @@ SciELO SUSHI API, disponível em [usage.apis.scielo.org](http://usage.apis.sciel
 - [Geolocation Report J1](#geolocation-report-j1-gr_j1): acessos por periódico considerando o país origiário do acesso
 - [Geolocation Report J4](#geolocation-report-j4-gr_j4): acessos por periódico considerando o país origiário do acesso e o ano de publicação dos documentos
 - [Language Report J1](#language-report-j1-lr_j1): acessos por periódico considerando o idioma dos documentos
+- [Language Report A1](#language-report-a1-lr_a1): acessos por documento considerando o idioma
 - [Language Report J4](#language-report-j4-lr_j4): acessos por periódico considerando o idioma e o ano de publicação dos documentos
 
 **Métricas**
@@ -385,6 +386,9 @@ Relatórios **CR_J1** descrevem o uso de uma coleção inteira. Esse relatório 
 
 #### Language Report J1 (LR_J1)
 Relatórios **LR_J1** descrevem o uso de periódicos considerando o idioma dos documentos acessados. Essa também é uma extensão do Project COUNTER R5 que foi contextualizada ao universo SciELO, que possui textos completos em Português, Inglês, Espanhol e outros idiomas (e isso, por vezes, para um mesmo artigo). Os resultados apresentados por esse relatório agregam as métricas por cada um dos idiomas. Assim, se um periódico possui 100 artigos em Português e 50 em Inglês, por exemplo, para cada um desses idiomas haverá um conjunto de métricas de acesso. Assim como o relatório **CR_J1**, relatórios **LR_J1** são acessados por meio do parâmetro _api=v2_.
+
+#### Language Report A1 (LR_A1)
+Relatórios **LR_A1** descrevem o uso de artigos considerando o idioma acessado. Essa também é uma extensão do Project COUNTER R5 que foi contextualizada ao universo SciELO, que possui textos completos em Português, Inglês, Espanhol e outros idiomas (e isso, por vezes, para um mesmo artigo). Os resultados apresentados por esse relatório agregam as métricas por cada um dos idiomas. Assim, se um artigo possui três versões, sendo uma em Português outra em Inglês e uma terceira em Espanhol, por exemplo, para cada um desses idiomas haverá um conjunto de métricas de acesso.
 
 #### Geolocation Report J1 (GR_J1)
 Relatórios **GR_J1** descrevem o uso de periódicos considerando o país de origem do acesso realizado aos documentos. Essa também é uma extensão do Project COUNTER R5 que foi contextualizada ao universo SciELO. Os resultados apresentados por esse relatório agregam as métricas por cada um dos países de origem dos acessos (em termos de códigos ISO). Assim como os relatórios **CR_J1** e **LR_J1**, relatórios **GR_J1** são acessados por meio do parâmetro `api=v2`.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ dev_requires = [
 
 setup(
     name='scielo-sushiapi',
-    version='0.9.1',
+    version='0.9.2',
     packages=find_packages(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests", "docs"]
     ),


### PR DESCRIPTION
#### O que esse PR faz?
Cria relatório LR_A1 que fornece contagens de acesso por artigo/idioma. Trata-se de uma versão mais detalhada do relatório LR_J1, que apresenta os dados agregados por periódico. Um editor pode estar interessado em saber qual versão (em termos de idioma) um certo artigo tem sido mais acessado.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
1. Instanciar a aplicação.
2. Povoar banco de dados.
3. Acessar o novo relatório fazendo:
    - http://127.0.0.1:6543/reports/lr_a1?begin_date=2018-01-01&end_date=2018-02-28&pid=S1415-790X2015000100025&fmt=json&collection=scl
    - http://127.0.0.1:6543/reports/lr_a1?begin_date=2018-01-01&end_date=2018-02-28&pid=S1415-790X2015000100025&fmt=tsv&collection=scl
    - http://usage.apis.scielo.org/reports/lr_a1?begin_date=2022-02-01&end_date=2022-02-28&pid=GSnQgG67q3MJcqpKXCfGCVv&fmt=json&collection=nbr
    - http://usage.apis.scielo.org/reports/lr_a1?begin_date=2022-02-01&end_date=2022-02-28&pid=GSnQgG67q3MJcqpKXCfGCVv&fmt=tsv&collection=nbr

#### Algum cenário de contexto que queira dar?
A tabela reponsável por povoar relatórios LR_A1 já foi preenchida no banco de dados do servidor. O próximo passo é fazer com que o usuário possa usar o código DOI de artigo para solicitar relatórios LR_A1 e IR_A1, de modo que o sistema retorne os acessos do sites clássico e novo numa única requisição.

#### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

#### Referências
N/A