### PR TITLE
Move relatório lr_a1 para a versão 2 da API

### DIFF
--- a/api/adapter.py
+++ b/api/adapter.py
@@ -1471,3 +1471,14 @@ def _tsv_report_gr_j4(result_query, params, exceptions):
             output['rows'].append(line)
 
     return output
+
+
+def _get_scielo_pids(result_query, field_pid_name):
+    article_scielo_ids = set()
+
+    for r in result_query:
+        str_pids = getattr(r, field_pid_name) or ''
+        els_pids = str_pids.split(',')
+        
+        article_scielo_ids = article_scielo_ids.union(set(els_pids))
+    return sorted(article_scielo_ids)

--- a/api/adapter.py
+++ b/api/adapter.py
@@ -294,12 +294,15 @@ def _json_lr_a1(result_query_reports_lr_a1, params, exceptions):
 
     report_items = {}
 
+
+    article_scielo_ids = _get_scielo_pids(result_query_reports_lr_a1, 'articlePID')
+
     for r in result_query_reports_lr_a1:
-        key = '-'.join([r.articleCollection, r.articlePID, r.articleLanguage])
+        key = '-'.join([r.articleDOI, r.articleLanguage])
 
         if key not in report_items:
             report_items[key] = {
-                'Item': r.articlePID,
+                'Item': r.articleDOI,
                 'Publisher': r.journalPublisher,
                 'Publisher_ID': [],
                 'Platform': params.get('platform', ''),
@@ -307,7 +310,7 @@ def _json_lr_a1(result_query_reports_lr_a1, params, exceptions):
                 'Publication_Date': '',
                 'Article_Language': r.articleLanguage,
                 'Article_Version': '',
-                'DOI': '',
+                'DOI': r.articleDOI,
                 'Proprietary_ID': '',
                 'Print_ISSN': '',
                 'Online_ISSN': '',
@@ -319,7 +322,7 @@ def _json_lr_a1(result_query_reports_lr_a1, params, exceptions):
                 'Parent_Online_ISSN': r.onlineISSN,
                 'Parent_URI': r.journalURI,
                 'Parent_Data_Type': 'Journal',
-                'Item_ID': [],
+                'Item_ID': article_scielo_ids,
                 'Data_Type': 'Article',
                 'Access_Type': 'Open Access',
                 'Access_Method': 'Regular',

--- a/api/adapter.py
+++ b/api/adapter.py
@@ -964,10 +964,19 @@ def _tsv_report_lr_a1(result_query, params, exceptions):
     result = {'headers': _tsv_header(params, exceptions)}
 
     article2values = {}
+    article2description = {}
+    article_scielo_pids = _get_scielo_pids(result_query, 'articlePID')    
     yms = ['Reporting_Period_Total']
 
     for ri in result_query:
-        article_key = (ri.printISSN, ri.onlineISSN, ri.journalTitle, ri.journalURI, ri.journalPublisher, ri.articleCollection, ri.articlePID, ri.articleLanguage)
+        if params.get('api', 'v1') == 'v2':
+            article_key = (ri.articleDOI, ri.articleLanguage)
+            article_description = (ri.printISSN, ri.onlineISSN, ri.journalTitle, ri.journalURI, ri.journalPublisher, ri.articleCollection, article_scielo_pids, ri.articleLanguage, ri.articleDOI)
+        else:
+            article_key = (ri.articlePID, ri.articleLanguage)
+            article_description = (ri.printISSN, ri.onlineISSN, ri.journalTitle, ri.journalURI, ri.journalPublisher, ri.articleCollection, ri.articlePID, ri.articleLanguage, '')
+
+        article2description[article_key] = article_description
 
         tir = getattr(ri, 'totalItemRequests')
         uir = getattr(ri, 'uniqueItemRequests')
@@ -996,27 +1005,27 @@ def _tsv_report_lr_a1(result_query, params, exceptions):
     for i in article2values:
         for j, metric_name in enumerate(['Total_Item_Requests', 'Unique_Item_Requests']):
             line = [
-                i[6],
-                i[4],
+                i[0],
+                article2description[i][4],
                 '',
                 'SciELO SUSHI API',
                 '',
                 '',
-                i[7],
-                '',
-                '',
-                '',
-                '',
-                '',
-                '',
-                i[2],
-                '',
-                '',
-                '',
-                '',
-                i[0],
                 i[1],
-                i[3],
+                '',
+                article2description[i][8],
+                '',
+                '',
+                '',
+                '',
+                article2description[i][2],
+                '',
+                '',
+                '',
+                '',
+                article2description[i][0],
+                article2description[i][1],
+                article2description[i][3],
                 '',
                 metric_name
             ]

--- a/api/models/sql_declarative.py
+++ b/api/models/sql_declarative.py
@@ -378,3 +378,18 @@ class AggrJournalGeolocationYOPYearMonthMetric(Base):
     total_item_investigations = Column(INTEGER, nullable=False)
     unique_item_requests = Column(INTEGER, nullable=False)
     unique_item_investigations = Column(INTEGER, nullable=False)
+
+
+class ArticleCode(Base):
+    __tablename__ = 'counter_article_code'
+    __table_args__ = (UniqueConstraint('collection', 'pid_v2', 'pid_v3', 'doi', name='uni_col_pid2_pid3_doi_cac'),)
+    __table_args__ += (Index('idx_p2_p3', 'pid_v2', 'pid_v3'),)
+    __table_args__ += (Index('idx_p2_doi', 'pid_v2', 'doi'),)
+    __table_args__ += (Index('idx_p3_doi', 'pid_v3', 'doi'),)
+
+    id = Column(INTEGER(unsigned=True), primary_key=True, autoincrement=True)
+
+    collection = Column(VARCHAR(3), nullable=False, primary_key=True)
+    pid_v2 = Column(VARCHAR(23), nullable=False, primary_key=True)
+    pid_v3 = Column(VARCHAR(23), nullable=False, primary_key=True)
+    doi = Column(VARCHAR(255), nullable=False, primary_key=True)

--- a/api/static/sql/procedures.sql
+++ b/api/static/sql/procedures.sql
@@ -386,6 +386,103 @@ END $$
 DELIMITER ;
 
 DELIMITER $$
+CREATE PROCEDURE LR_A1_ARTICLE_TOTALS(IN beginDate varchar(7), IN endDate varchar(7), IN pid varchar(23), IN collection varchar(3))
+BEGIN
+    SELECT
+        cj.print_issn as printISSN,
+        cj.online_issn as onlineISSN,
+        cjc.title as journalTitle,
+        cjc.uri as journalURI,
+        cjc.publisher_name as journalPublisher,
+        ca.collection as articleCollection,
+        ca.pid as articlePID,
+        cal.`language` as articleLanguage,
+		MIN(aalymm.`year_month`) AS beginDate,
+		MAX(aalymm.`year_month`) AS endDate,
+        sum(aalymm.total_item_requests) as totalItemRequests,
+        sum(aalymm.unique_item_requests) as uniqueItemRequests
+    FROM
+        aggr_article_language_year_month_metric aalymm
+    JOIN
+        counter_article ca ON ca.id = aalymm.article_id 
+    JOIN
+        counter_journal cj ON cj.id = ca.idjournal_a 
+    JOIN
+        counter_journal_collection cjc ON cjc.idjournal_jc = ca.idjournal_a 
+    JOIN 
+        counter_article_language cal ON cal.id = aalymm.language_id 
+    WHERE
+        aalymm.article_id in (
+            select 
+                id
+            from 
+                counter_article ca 
+            where 
+                ca.pid = pid AND 
+                ca.collection = collection
+        ) AND
+        cjc.collection = collection AND
+        aalymm.collection = collection AND
+        `year_month` BETWEEN beginDate AND endDate
+    GROUP BY
+        articlePID,
+        articleLanguage
+    ORDER BY
+        articlePID,
+        articleLanguage;
+END $$
+DELIMITER ;
+
+DELIMITER $$
+CREATE PROCEDURE LR_A1_ARTICLE_MONTHLY(IN beginDate varchar(7), IN endDate varchar(7), IN pid varchar(23), IN collection varchar(3))
+BEGIN
+    SELECT
+        cj.print_issn as printISSN,
+        cj.online_issn as onlineISSN,
+        cjc.title as journalTitle,
+        cjc.uri as journalURI,
+        cjc.publisher_name as journalPublisher,
+        ca.collection as articleCollection,
+        ca.pid as articlePID,
+        cal.`language` as articleLanguage,
+        aalymm.`year_month` as yearMonth,
+        sum(aalymm.total_item_requests) as totalItemRequests,
+        sum(aalymm.unique_item_requests) as uniqueItemRequests
+    FROM
+        aggr_article_language_year_month_metric aalymm
+    JOIN
+        counter_article ca ON ca.id = aalymm.article_id 
+    JOIN
+        counter_journal cj ON cj.id = ca.idjournal_a 
+    JOIN
+        counter_journal_collection cjc ON cjc.idjournal_jc = ca.idjournal_a 
+    JOIN 
+        counter_article_language cal ON cal.id = aalymm.language_id 
+    WHERE
+        aalymm.article_id in (
+            select 
+                id
+            from 
+                counter_article ca 
+            where 
+                ca.pid = pid AND 
+                ca.collection = collection
+        ) AND
+        cjc.collection = collection AND
+        aalymm.collection = collection AND
+        `year_month` BETWEEN beginDate AND endDate
+    GROUP BY
+        articlePID,
+        articleLanguage,
+        yearMonth
+    ORDER BY
+        articlePID,
+        articleLanguage,
+        yearMonth;
+END $$
+DELIMITER ;
+
+DELIMITER $$
 CREATE PROCEDURE V2_TR_J1_JOURNAL_TOTALS(IN beginDate date, IN endDate date, IN issn varchar(9), IN collection varchar(3))
 BEGIN
 	SELECT

--- a/api/static/sql/procedures_v2_lr_a1.sql
+++ b/api/static/sql/procedures_v2_lr_a1.sql
@@ -1,98 +1,151 @@
 DELIMITER $$
-CREATE PROCEDURE LR_A1_ARTICLE_TOTALS(IN beginDate varchar(7), IN endDate varchar(7), IN pid varchar(23), IN collection varchar(3))
+CREATE PROCEDURE V2_LR_A1_ARTICLE_MONTHLY(IN beginDate varchar(7), IN endDate varchar(7), IN pidOrDoi varchar(255), IN collectionAcronym varchar(3), IN collectionAcronymExtra varchar(3))
 BEGIN
-    SELECT
-        cj.print_issn as printISSN,
-        cj.online_issn as onlineISSN,
-        cjc.title as journalTitle,
-        cjc.uri as journalURI,
-        cjc.publisher_name as journalPublisher,
-        ca.collection as articleCollection,
-        ca.pid as articlePID,
-        cal.`language` as articleLanguage,
-		MIN(aalymm.`year_month`) AS beginDate,
-		MAX(aalymm.`year_month`) AS endDate,
-        sum(aalymm.total_item_requests) as totalItemRequests,
-        sum(aalymm.unique_item_requests) as uniqueItemRequests
-    FROM
-        aggr_article_language_year_month_metric aalymm
-    JOIN
-        counter_article ca ON ca.id = aalymm.article_id 
-    JOIN
-        counter_journal cj ON cj.id = ca.idjournal_a 
-    JOIN
-        counter_journal_collection cjc ON cjc.idjournal_jc = ca.idjournal_a 
-    JOIN 
-        counter_article_language cal ON cal.id = aalymm.language_id 
-    WHERE
-        aalymm.article_id in (
-            select 
-                id
-            from 
-                counter_article ca 
-            where 
-                ca.pid = pid AND 
-                ca.collection = collection
-        ) AND
-        cjc.collection = collection AND
-        aalymm.collection = collection AND
-        `year_month` BETWEEN beginDate AND endDate
-    GROUP BY
-        articlePID,
-        articleLanguage
-    ORDER BY
-        articlePID,
-        articleLanguage;
+	SELECT 
+	    GROUP_CONCAT(DISTINCT cjc.collection) AS articleCollection,
+	    cjc.title AS journalTitle,
+	    cjc.uri AS journalURI,
+	    cjc.publisher_name AS journalPublisher,
+	    cj.print_issn AS printISSN,
+	    cj.online_issn AS onlineISSN,
+	    GROUP_CONCAT(DISTINCT T3.doi) as articleDOI,
+	    GROUP_CONCAT(DISTINCT ca.pid) AS articlePID,
+	    GROUP_CONCAT(DISTINCT ca.yop) AS articleYOP,
+	    cal.`language` AS articleLanguage,
+	    yearMonth,
+	    SUM(totalItemRequests) AS totalItemRequests,
+	    SUM(uniqueItemRequests) AS uniqueItemRequests	
+	FROM (
+	    SELECT
+	        aalymm.collection AS collection,
+	        aalymm.article_id AS aid,
+	        doi,
+	        aalymm.language_id AS lid,
+	        aalymm.`year_month` AS yearMonth,
+	        sum(aalymm.total_item_requests) AS totalItemRequests,
+	        sum(aalymm.unique_item_requests) AS uniqueItemRequests
+	    FROM
+	        aggr_article_language_year_month_metric aalymm
+	    RIGHT JOIN
+	        (	
+	            SELECT 
+	                id,
+	                doi
+	            FROM 
+	                counter_article ca 
+	            RIGHT JOIN (
+	                SELECT
+	                    cac.pid_v2 AS pid,
+	                    cac.doi as doi
+	                FROM
+	                    counter_article_code cac
+	                WHERE 
+	                    cac.pid_v2 = pidOrDoi OR
+	                    cac.pid_v3 = pidOrDoi OR
+	                    cac.doi = pidOrDoi
+	                UNION
+	                SELECT
+	                    cac.pid_v3 AS pid,
+	                    cac.doi as doi
+	                FROM
+	                    counter_article_code cac
+	                WHERE 
+	                    cac.pid_v2 = pidOrDoi OR
+	                    cac.pid_v3 = pidOrDoi OR
+	                    cac.doi = pidOrDoi
+	            ) AS T1 ON T1.pid = ca.pid	
+	        ) AS T2 ON T2.id = aalymm.article_id
+	    WHERE
+	        (aalymm.collection IN (collectionAcronym, collectionAcronymExtra)) AND
+	        (`year_month` BETWEEN beginDate AND endDate)
+	    GROUP BY
+	        aalymm.collection,
+	        aalymm.article_id,
+	        aalymm.language_id,
+	        aalymm.`year_month`
+	) AS T3
+	LEFT JOIN counter_article_language cal ON cal.id = T3.lid
+	LEFT JOIN counter_article ca ON ca.id = T3.aid
+	LEFT JOIN counter_journal_collection cjc ON (cjc.idjournal_jc = ca.idjournal_a AND cjc.collection = ca.collection)
+	LEFT JOIN counter_journal cj ON cj.id = ca.idjournal_a
+	GROUP BY
+	    articleLanguage,
+	    yearMonth;
 END $$
 DELIMITER ;
 
 DELIMITER $$
-CREATE PROCEDURE LR_A1_ARTICLE_MONTHLY(IN beginDate varchar(7), IN endDate varchar(7), IN pid varchar(23), IN collection varchar(3))
+CREATE PROCEDURE V2_LR_A1_ARTICLE_TOTALS(IN beginDate varchar(7), IN endDate varchar(7), IN pidOrDoi varchar(255), IN collectionAcronym varchar(3), IN collectionAcronymExtra varchar(3))
 BEGIN
-    SELECT
-        cj.print_issn as printISSN,
-        cj.online_issn as onlineISSN,
-        cjc.title as journalTitle,
-        cjc.uri as journalURI,
-        cjc.publisher_name as journalPublisher,
-        ca.collection as articleCollection,
-        ca.pid as articlePID,
-        aalymm.article_id as articleID,
-        aalymm.language_id as languageCode,
-        cal.`language` as articleLanguage,
-        aalymm.`year_month` as yearMonth,
-        sum(aalymm.total_item_requests) as totalItemRequests,
-        sum(aalymm.unique_item_requests) as uniqueItemRequests
-    FROM
-        aggr_article_language_year_month_metric aalymm
-    JOIN
-        counter_article ca ON ca.id = aalymm.article_id 
-    JOIN
-        counter_journal cj ON cj.id = ca.idjournal_a 
-    JOIN
-        counter_journal_collection cjc ON cjc.idjournal_jc = ca.idjournal_a 
-    JOIN 
-        counter_article_language cal ON cal.id = aalymm.language_id 
-    WHERE
-        aalymm.article_id in (
-            select 
-                id
-            from 
-                counter_article ca 
-            where 
-                ca.pid = pid AND 
-                ca.collection = collection
-        ) AND
-        cjc.collection = collection AND
-        aalymm.collection = collection AND
-        `year_month` BETWEEN beginDate AND endDate
-    GROUP BY
-        articleID,
-        languageCode,
-        yearMonth
-    ORDER BY
-        articleID,
-        languageCode,
-        yearMonth;
+	SELECT 
+	    GROUP_CONCAT(DISTINCT cjc.collection) AS articleCollection,
+	    cjc.title AS journalTitle,
+	    cjc.uri AS journalURI,
+	    cjc.publisher_name AS journalPublisher,
+	    cj.print_issn AS printISSN,
+	    cj.online_issn AS onlineISSN,
+	    GROUP_CONCAT(DISTINCT T3.doi) as articleDOI,
+	    GROUP_CONCAT(DISTINCT ca.pid) AS articlePID,
+	    GROUP_CONCAT(DISTINCT ca.yop) AS articleYOP,
+	    cal.`language` AS articleLanguage,
+		MIN(T3.yearMonth) AS beginDate,
+		MAX(T3.yearMonth) AS endDate,
+	    SUM(totalItemRequests) AS totalItemRequests,
+	    SUM(uniqueItemRequests) AS uniqueItemRequests	
+	FROM (
+	    SELECT
+	        aalymm.collection AS collection,
+	        aalymm.article_id AS aid,
+	        doi,
+	        aalymm.language_id AS lid,
+	        aalymm.`year_month` AS yearMonth,
+	        sum(aalymm.total_item_requests) AS totalItemRequests,
+	        sum(aalymm.unique_item_requests) AS uniqueItemRequests
+	    FROM
+	        aggr_article_language_year_month_metric aalymm
+	    RIGHT JOIN
+	        (	
+	            SELECT 
+	                id,
+	                doi
+	            FROM 
+	                counter_article ca 
+	            RIGHT JOIN (
+	                SELECT
+	                    cac.pid_v2 AS pid,
+	                    cac.doi AS doi
+	                FROM
+	                    counter_article_code cac
+	                WHERE 
+	                    cac.pid_v2 = pidOrDoi OR
+	                    cac.pid_v3 = pidOrDoi OR
+	                    cac.doi = pidOrDoi
+	                UNION
+	                SELECT
+	                    cac.pid_v3 AS pid,
+	                    cac.doi AS doi
+	                FROM
+	                    counter_article_code cac
+	                WHERE 
+	                    cac.pid_v2 = pidOrDoi OR
+	                    cac.pid_v3 = pidOrDoi OR
+	                    cac.doi = pidOrDoi
+	            ) AS T1 ON T1.pid = ca.pid	
+	        ) AS T2 ON T2.id = aalymm.article_id
+	    WHERE
+	        (aalymm.collection IN (collectionAcronym, collectionAcronymExtra)) AND
+	        (`year_month` BETWEEN beginDate AND endDate)
+	    GROUP BY
+	        aalymm.collection,
+	        aalymm.article_id,
+	        aalymm.language_id,
+	        aalymm.`year_month`
+	) AS T3
+	LEFT JOIN counter_article_language cal ON cal.id = T3.lid
+	LEFT JOIN counter_article ca ON ca.id = T3.aid
+	LEFT JOIN counter_journal_collection cjc ON (cjc.idjournal_jc = ca.idjournal_a AND cjc.collection = ca.collection)
+	LEFT JOIN counter_journal cj ON cj.id = ca.idjournal_a
+	GROUP BY
+	    articleLanguage;
 END $$
 DELIMITER ;

--- a/api/utils.py
+++ b/api/utils.py
@@ -116,7 +116,7 @@ def format_error_messages(exceptions: list):
 
 
 def set_collection_extra(report_id, attrs):
-    if report_id in ('cr_j1', 'gr_j1', 'lr_j1', 'gr_j4', 'lr_j4'):
+    if report_id in ('cr_j1', 'gr_j1', 'lr_j1', 'gr_j4', 'lr_j4', 'lr_a1'):
         if attrs['collection'] == 'scl':
             attrs.update({'collection_extra': 'nbr'})
 

--- a/api/values.py
+++ b/api/values.py
@@ -68,6 +68,9 @@ DB_CALL_IR_A1_JOURNAL_MONTHLY = 'CALL IR_A1_JOURNAL_MONTHLY("%s", "%s", "%s", "%
 DB_CALL_V2_TR_J1_JOURNAL_TOTALS = 'CALL V2_TR_J1_JOURNAL_TOTALS("%s", "%s", "%s", "%s")'
 DB_CALL_V2_TR_J1_JOURNAL_MONTHLY = 'CALL V2_TR_J1_JOURNAL_MONTHLY("%s", "%s", "%s", "%s")'
 
+DB_CALL_V2_LR_A1_ARTICLE_TOTALS = 'CALL V2_LR_A1_ARTICLE_TOTALS("%s", "%s", "%s", "%s", "%s")'
+DB_CALL_V2_LR_A1_ARTICLE_MONTHLY = 'CALL V2_LR_A1_ARTICLE_MONTHLY("%s", "%s", "%s", "%s", "%s")'
+
 DB_CALL_V2_LR_J1_JOURNAL_TOTALS = 'CALL V2_LR_J1_JOURNAL_TOTALS("%s", "%s", "%s", "%s", "%s")'
 DB_CALL_V2_LR_J1_JOURNAL_MONTHLY = 'CALL V2_LR_J1_JOURNAL_MONTHLY("%s", "%s", "%s", "%s", "%s")'
 
@@ -157,6 +160,9 @@ GRANULARITY_MODE_REPORT_TO_PROCEDURE_AND_PARAMETERS = {
 
 V2_GRANULARITY_MODE_REPORT_TO_PROCEDURE_AND_PARAMETERS = {
     'totals': {
+        'pid': {
+            'lr_a1': (DB_CALL_V2_LR_A1_ARTICLE_TOTALS, ['begin_date', 'end_date', 'pid', 'collection', 'collection_extra']),
+        },
         'issn': {
             'gr_j1': (DB_CALL_V2_GR_J1_JOURNAL_TOTALS, ['begin_date', 'end_date', 'issn', 'collection', 'collection_extra']),
             'gr_j4': (DB_CALL_V2_GR_J4_JOURNAL_TOTALS, ['begin_date', 'end_date', 'issn', 'collection', 'collection_extra']),
@@ -182,6 +188,9 @@ V2_GRANULARITY_MODE_REPORT_TO_PROCEDURE_AND_PARAMETERS = {
         }
     },
     'monthly': {
+        'pid': {
+            'lr_a1': (DB_CALL_V2_LR_A1_ARTICLE_MONTHLY, ['begin_date', 'end_date', 'pid', 'collection', 'collection_extra']),
+        },
         'issn': {
             'gr_j1': (DB_CALL_V2_GR_J1_JOURNAL_MONTHLY, ['begin_date', 'end_date', 'issn', 'collection', 'collection_extra']),
             'gr_j4': (DB_CALL_V2_GR_J4_JOURNAL_MONTHLY, ['begin_date', 'end_date', 'issn', 'collection', 'collection_extra']),

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ dev_requires = [
 
 setup(
     name='scielo-sushiapi',
-    version='0.9.2',
+    version='0.9.3',
     packages=find_packages(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests", "docs"]
     ),


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a capacidade de obter relatórios lr_a1 usando a versão 2 da SciELO SUSHI API. Na prática, isso significa que não é mais necessário fazer duas consultas e conhecer dois PIDs de um mesmo documento. Basta informar um dos PIDs ou mesmo o DOI que osistema se encarregará de entregar os dados de acesso já somados para todos os sites relacionados a uma coleção (clássico e novo).

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
1. Instancie a aplicação
2. Povoe o banco de dados, inclusive a nova tabela counter_article_code
3. Faça chamadas ao relatório lr_a1 informando o parâmetro api=v2 e um dos códigos (PID v2, PID v3 ou DOI)

#### Algum cenário de contexto que queira dar?
N/A

#### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

#### Referências
N/A